### PR TITLE
Add check for isofiles dir before removing it and remove as root.

### DIFF
--- a/debian/make-preseed-iso.sh
+++ b/debian/make-preseed-iso.sh
@@ -6,7 +6,7 @@ set -e
 
 function extract_iso() {
   echo "Extracting iso: $1..."
-  [ -d isofiles ] && echo "Removing temp files. This must be done as root"; sudo rm -rf isofiles
+  [ -d isofiles ] && echo "Removing temp files. This must be done as root" && sudo rm -rf isofiles
   mkdir isofiles
   bsdtar -C isofiles -xf "$1"
 }

--- a/debian/make-preseed-iso.sh
+++ b/debian/make-preseed-iso.sh
@@ -6,7 +6,7 @@ set -e
 
 function extract_iso() {
   echo "Extracting iso: $1..."
-  [ -d isofiles ] && sudo rm -rf isofiles
+  [ -d isofiles ] && echo "Removing temp files. This must be done as root"; sudo rm -rf isofiles
   mkdir isofiles
   bsdtar -C isofiles -xf "$1"
 }

--- a/debian/make-preseed-iso.sh
+++ b/debian/make-preseed-iso.sh
@@ -6,7 +6,7 @@ set -e
 
 function extract_iso() {
   echo "Extracting iso: $1..."
-  rm -rf isofiles
+  [ -d isofiles ] && sudo rm -rf isofiles
   mkdir isofiles
   bsdtar -C isofiles -xf "$1"
 }


### PR DESCRIPTION
Well now I'm making it too complicated. I'm just gonna wait for the approval.

Isofiles has to preserve all the permissions within the iso so it has to be removed with sudo. I put a little message in there so the user will know why they are being prompted for their password.